### PR TITLE
Terminate SpeechClientBridge after WS connection is closed

### DIFF
--- a/python/realtime-transcriptions/server.py
+++ b/python/realtime-transcriptions/server.py
@@ -63,6 +63,8 @@ def transcript(ws):
             print(f"Media WS: Received event 'stop': {message}")
             print("Stopping...")
             break
+
+    bridge.terminate()
     print("WS connection closed")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Close connection to google ASR after twilio closes websocket for streaming audio. It the connection to google ASR is not closed, google is going to automatically force close the connection after some time of inactivity and throw an exception. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
