### PR TITLE
Fix streaming errors in python realtime-transcription example.

### DIFF
--- a/python/realtime-transcriptions/SpeechClientBridge.py
+++ b/python/realtime-transcriptions/SpeechClientBridge.py
@@ -31,7 +31,7 @@ class SpeechClientBridge:
             self._on_response(response)
 
             if self._ended:
-              break;
+                break
 
     def generator(self):
         while not self._ended:

--- a/python/realtime-transcriptions/SpeechClientBridge.py
+++ b/python/realtime-transcriptions/SpeechClientBridge.py
@@ -1,34 +1,30 @@
 import queue
-from threading import Thread
+
 from google.cloud import speech
-from google.cloud.speech import types
+
 
 class SpeechClientBridge:
     def __init__(self, streaming_config, on_response):
         self._on_response = on_response
         self._queue = queue.Queue()
         self._ended = False
+        self.streaming_config = streaming_config
 
+    def start(self):
         client = speech.SpeechClient()
-        responses = client.streaming_recognize(
-            streaming_config, 
-            self.get_requests()
+        stream = self.generator()
+        requests = (
+            speech.StreamingRecognizeRequest(audio_content=content)
+            for content in stream
         )
-        self.process_responses(responses)
+        responses = client.streaming_recognize(self.streaming_config, requests)
+        self.process_responses_loop(responses)
 
     def terminate(self):
         self._ended = True
 
     def add_request(self, buffer):
-        self._queue.put(types.StreamingRecognizeRequest(audio_content=bytes(buffer)))
-
-    def get_requests(self):
-        while not self._ended:
-            yield self._queue.get()
-
-    def process_responses(self, responses):
-        thread = Thread(target=self.process_responses_loop, args=[responses])
-        thread.start()
+        self._queue.put(bytes(buffer), block=False)
 
     def process_responses_loop(self, responses):
         for response in responses:
@@ -36,3 +32,25 @@ class SpeechClientBridge:
 
             if self._ended:
               break;
+
+    def generator(self):
+        while not self._ended:
+            # Use a blocking get() to ensure there's at least one chunk of
+            # data, and stop iteration if the chunk is None, indicating the
+            # end of the audio stream.
+            chunk = self._queue.get()
+            if chunk is None:
+                return
+            data = [chunk]
+
+            # Now consume whatever other data's still buffered.
+            while True:
+                try:
+                    chunk = self._queue.get(block=False)
+                    if chunk is None:
+                        return
+                    data.append(chunk)
+                except queue.Empty:
+                    break
+
+            yield b"".join(data)

--- a/python/realtime-transcriptions/requirements.txt
+++ b/python/realtime-transcriptions/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.0.2
 Flask-Sockets==0.2.1
-google-cloud-speech==0.36.3
+google-cloud-speech==2.0.1

--- a/python/realtime-transcriptions/server.py
+++ b/python/realtime-transcriptions/server.py
@@ -20,10 +20,12 @@ streaming_config = StreamingRecognitionConfig(config=config, interim_results=Tru
 app = Flask(__name__)
 sockets = Sockets(app)
 
-@app.route('/twiml', methods=['POST'])
+
+@app.route("/twiml", methods=["POST"])
 def return_twiml():
     print("POST TwiML")
-    return render_template('streams.xml')
+    return render_template("streams.xml")
+
 
 def on_transcription_response(response):
     if not response.results:
@@ -36,7 +38,8 @@ def on_transcription_response(response):
     transcription = result.alternatives[0].transcript
     print("Transcription: " + transcription)
 
-@sockets.route('/')
+
+@sockets.route("/")
 def transcript(ws):
     print("WS connection opened")
     bridge = SpeechClientBridge(streaming_config, on_transcription_response)
@@ -66,10 +69,13 @@ def transcript(ws):
     bridge.terminate()
     print("WS connection closed")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from gevent import pywsgi
     from geventwebsocket.handler import WebSocketHandler
 
-    server = pywsgi.WSGIServer(('', HTTP_SERVER_PORT), app, handler_class=WebSocketHandler)
+    server = pywsgi.WSGIServer(
+        ("", HTTP_SERVER_PORT), app, handler_class=WebSocketHandler
+    )
     print("Server listening on: http://localhost:" + str(HTTP_SERVER_PORT))
     server.serve_forever()


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Fixes streaming issues in the realtime-transcription python example (as reported in issue https://github.com/twilio/media-streams/issues/72). Previously, the `SpeechClientBridge` was hanging on a synchronous process in `init`. Now, that process happens in a background thread.
The `generator` method was taken from the python example from [google cloud](https://github.com/googleapis/python-speech/blob/master/samples/microphone/transcribe_streaming_mic.py).
Also linted the realtime-transcription example with `black` and `isort`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
