### PR TITLE
handled uncaught exception

### DIFF
--- a/node/dialogflow-integration/server.js
+++ b/node/dialogflow-integration/server.js
@@ -36,7 +36,7 @@ app.ws("/media", (ws, req) => {
   let client;
   try {
     client = new Twilio();
-  } catch(err) {
+  } catch (err) {
     if (process.env.TWILIO_ACCOUNT_SID === undefined) {
       console.error('Ensure that you have set your environment variable TWILIO_ACCOUNT_SID. This can be copied from https://twilio.com/console');
       console.log('Exiting');
@@ -130,6 +130,11 @@ app.ws("/media", (ws, req) => {
   });
 
 
+});
+
+//Catching any unhandled exception through out the process
+process.on('uncaughtException', (error) => {
+  console.log("unhandled exception caught", error)
 });
 
 const listener = app.listen(PORT, () => {


### PR DESCRIPTION

**Error handler for uncaught exception**

> **Issue:**  While using this repository we encountered issues in the pipeline due to some errors thrown by the internal libraries which stopped the server directly. This resulted in disconnecting all the ongoing calls. In this case, the server had to restart and the calls have to be initiated again which added up to a bad user expireince.

>**Solution:** We have tried to cover all the unhandled exceptions in the server.js file by using the process.on "uncaught exception" event provided by NodeJs, which catches all the unhandled exceptions (if any) and prevents the server from stopping. Hence, all the ongoing calls will not be disconnected due to some error that originated in the pipeline of a single call.

- [x] I acknowledge that all my contributions will be made under the project's license.
